### PR TITLE
Add a delay of 215 ms for the hover after the player attacks

### DIFF
--- a/src/main/java/assets/game.js
+++ b/src/main/java/assets/game.js
@@ -115,7 +115,7 @@ function markHits(board, elementId, surrenderText) {
 
 
 
-        }, 2000);
+        }, 215);
     }
 
 


### PR DESCRIPTION
This prevents the hover from showing up as soon as they attack, there is a slight delay, meaning they can spam attacks without seeing the hover every attack (less annoying for user experience).