### PR TITLE
Fixed out of bounds bugs and tests

### DIFF
--- a/src/main/java/cs361/battleships/models/Board.java
+++ b/src/main/java/cs361/battleships/models/Board.java
@@ -36,6 +36,9 @@ public class Board {
 		int shipSize = ship.getShipSize();
 		//List<Square> occupiedSquares = getBoardOccupiedSquares();
 
+		System.out.println(x);
+		System.out.println(y);
+		System.out.println("\n");
 		// Check for the user trying to place multiple of the same ship type
 		for(Ship item : shipList){
 			if(item.getShipSize() == ship.getShipSize()){
@@ -219,6 +222,8 @@ public class Board {
 	}
 
 	private boolean SubOutBounds(int x, char y, boolean isVertical) {
+		System.out.println(x);
+		System.out.println(y);
 		if(isVertical){
 			if((char)(y+1) == 'L'){
 				return true;
@@ -430,14 +435,16 @@ public class Board {
 		int x = square.getRow();
 		char y = square.getColumn();
 
-		int minX = 1;
-		char minY = 'A';
+		int minX = 2;
+		char minY = 'B';
 
-		if(x < minX || x > minX + this.getXDimension()){
+		System.out.println("X: " + this.getXDimension());
+		System.out.println("Y: " + this.getYDimension());
+		if(x < minX || x > minX + this.getXDimension() - 1){
 			return false;
 		}
 
-		if(y < minY || y > minY + this.getYDimension()){
+		if(y < minY || y > minY + this.getYDimension() - 1){
 			return false;
 		}
 		return true;

--- a/src/test/java/cs361/battleships/models/BoardTest.java
+++ b/src/test/java/cs361/battleships/models/BoardTest.java
@@ -46,7 +46,7 @@ public class BoardTest {
     @Test
     public void testValidPlaceShipDestroyer(){
         Board board = new Board();
-        assertTrue(board.placeShip(new Destroyer(), 3, 'A', true));
+        assertTrue(board.placeShip(new Destroyer(), 3, 'B', true));
     }
 
     //Checking invalid Battleship placement
@@ -66,14 +66,14 @@ public class BoardTest {
     @Test
     public void testInvalidOverlapPlacement(){
         Board board = new Board();
-        assertTrue(board.placeShip(new Battleship(), 1, 'H', true));
+        assertTrue(board.placeShip(new Battleship(), 2, 'H', true));
         assertFalse(board.placeShip(new Minesweeper(), 3, 'G', false));
     }
 
     @Test
     public void testValidOverlapPlacement(){
         Board board = new Board();
-        assertTrue(board.placeSubShip(new Submarine(), 1, 'H', true, true));
+        assertTrue(board.placeSubShip(new Submarine(), 2, 'H', true, true));
         assertTrue(board.placeShip(new Minesweeper(), 3, 'G', false));
     }
 
@@ -87,7 +87,7 @@ public class BoardTest {
     @Test
     public void testInvalidGamePlacement(){
         Game game = new Game();
-        assertTrue(game.placeShip(new Battleship(), 1, 'A', false));
+        assertTrue(game.placeShip(new Battleship(), 2, 'B', false));
         assertTrue(game.placeShip(new Minesweeper(), 5, 'B', true));
         assertTrue(game.placeShip(new Destroyer(), 7, 'F', false));
 
@@ -96,16 +96,15 @@ public class BoardTest {
     @Test
     public void testGame(){
         Game game = new Game();
-        assertTrue(game.placeShip(new Battleship(), 1, 'A', false));
+        assertTrue(game.placeShip(new Battleship(), 2, 'B', false));
         assertTrue(game.placeShip(new Minesweeper(), 5, 'B', true));
         assertTrue(game.placeShip(new Destroyer(), 7, 'F', false));
         assertFalse(game.attack(12, 'A'));
         assertTrue(game.attack(5, 'B'));
         assertTrue(game.attack(6, 'B'));
-        assertTrue(game.attack(1, 'A'));
-        assertTrue(game.attack(1, 'B'));
-        assertTrue(game.attack(1, 'C'));
-        assertTrue(game.attack(1, 'D'));
+        assertTrue(game.attack(2, 'B'));
+        assertTrue(game.attack(2, 'B'));
+        assertTrue(game.attack(2, 'D'));
         assertTrue(game.attack(7, 'F'));
         assertTrue(game.attack(7, 'G'));
         assertTrue(game.attack(7, 'H'));
@@ -116,7 +115,7 @@ public class BoardTest {
     @Test
     public void testUniqueShips(){
         Game game = new Game();
-        assertTrue(game.placeShip(new Battleship(), 1, 'A', false));
+        assertTrue(game.placeShip(new Battleship(), 2, 'B', false));
         assertFalse(game.placeShip(new Battleship(), 2, 'A', false));
         assertTrue(game.placeShip(new Minesweeper(), 5, 'B', true));
         assertFalse(game.placeShip(new Minesweeper(), 5, 'C', true));

--- a/src/test/java/cs361/battleships/models/GameTest.java
+++ b/src/test/java/cs361/battleships/models/GameTest.java
@@ -44,7 +44,7 @@ public class GameTest { // This class has 100% coverage of all lines in Game.jav
         Ship ship = new Minesweeper();
         Game game = new Game();
 
-        assertTrue(game.placeShip(ship,4, 'A', false));
+        assertTrue(game.placeShip(ship,4, 'B', false));
     }
 
     @Test
@@ -70,8 +70,8 @@ public class GameTest { // This class has 100% coverage of all lines in Game.jav
         Ship ship = new Minesweeper();
         Game game = new Game();
 
-        assertTrue(game.attack(10, 'A'));
-        assertTrue(game.attack(1, 'B'));
+        assertTrue(game.attack(10, 'B'));
+        assertTrue(game.attack(2, 'B'));
         assertTrue(game.attack(2, 'C'));
         assertTrue(game.attack(3, 'D'));
         assertTrue(game.attack(4, 'E'));
@@ -87,7 +87,7 @@ public class GameTest { // This class has 100% coverage of all lines in Game.jav
     @Test
     public void testShipPlacement(){ // Test class for ship placement
         Game game = new Game(); // Creates new game
-        assertTrue(game.placeShip(new Minesweeper(), 1, 'A', true)); // places minesweeper ship at 1A vertically
+        assertTrue(game.placeShip(new Minesweeper(), 2, 'B', true)); // places minesweeper ship at 1A vertically
         assertTrue(game.placeShip(new Destroyer(), 5, 'C', true)); // places destroyer ship at 1A vertically (This test currently fails)
         assertFalse(game.placeShip(new Minesweeper(), 1, 'J', true)); // places 4th ship on board (not possible)
         assertFalse(game.placeShip(new Minesweeper(), 1, 'A', true)); // places ship in already chosen location (not possible)
@@ -97,8 +97,8 @@ public class GameTest { // This class has 100% coverage of all lines in Game.jav
         assertFalse(gamebp.placeShip(new Minesweeper(), 0, 'A', true)); // places minesweeper ship at 0A vertically (not possible)
         assertFalse(gamebp.placeShip(new Minesweeper(), 1, 'Z', true)); // places minesweeper ship at 1Z vertically (not possible)
         Game game2 = new Game();
-        assertTrue(game2.placeShip(new Minesweeper(), 1, 'A', false)); // places minesweeper ship at 1A horizontally
-        assertTrue(game2.placeShip(new Destroyer(), 9, 'A', false)); // places destroyer ship at 1A horizontally
+        assertTrue(game2.placeShip(new Minesweeper(), 2, 'B', false)); // places minesweeper ship at 1A horizontally
+        assertTrue(game2.placeShip(new Destroyer(), 9, 'B', false)); // places destroyer ship at 1A horizontally
         Game gamebph = new Game();
         assertFalse(gamebph.placeShip(new Minesweeper(), 0, 'A', false)); // places minesweeper ship at 0A horizontally (not possible)
         assertFalse(gamebph.placeShip(new Minesweeper(), 1, 'Z', false)); // places minesweeper ship at 1Z horizontally (not possible)
@@ -110,7 +110,7 @@ public class GameTest { // This class has 100% coverage of all lines in Game.jav
     @Test
     public void testAttack(){ // Test class to test attacks from player and AI
         Game game = new Game(); // Creates new game
-        assertTrue(game.attack(1, 'A')); // attacks at 1A
+        assertTrue(game.attack(2, 'B')); // attacks at 1A
         assertTrue(game.attack(10, 'J')); // attacks at 10J
         assertFalse(game.attack(12, 'A'));  // attacks at 11A (not possible)
         assertFalse(game.attack(1, 'Z')); // attacks at 1Z (not possible)
@@ -122,26 +122,26 @@ public class GameTest { // This class has 100% coverage of all lines in Game.jav
     public void testMultipleRadar() {
         Game game = new Game();
         Board board = new Board();
-        board.placeShip(new Destroyer(), 1, 'A', false);
-        board.placeShip(new Minesweeper(), 3, 'A', false);
-        board.placeShip(new Battleship(), 5, 'A', false);
-        board.placeSubShip(new Submarine(), 5, 'A', false, true);
-        assert (AtackStatus.HIT == board.attack(1, 'A').getResults().get(0));
-        assert (AtackStatus.MISS == board.attack(1, 'B').getResults().get(0));
-        assert (AtackStatus.HIT == board.attack(1, 'C').getResults().get(0));
-        assert (AtackStatus.SUNK == board.attack(1, 'B').getResults().get(0));
-        assert (AtackStatus.RADAR == board.radarAttack(4, 'D').getResults().get(0));
-        assert (AtackStatus.RADAR == board.radarAttack(6, 'A').getResults().get(0));
-        assert (AtackStatus.INVALID == board.radarAttack(2, 'C').getResults().get(0));
+        board.placeShip(new Destroyer(), 2, 'B', false);
+        board.placeShip(new Minesweeper(), 3, 'B', false);
+        board.placeShip(new Battleship(), 5, 'B', false);
+        board.placeSubShip(new Submarine(), 5, 'B', false, true);
+        assert (AtackStatus.HIT == board.attack(2, 'B').getResults().get(0));
+        assert (AtackStatus.MISS == board.attack(2, 'C').getResults().get(0));
+        assert (AtackStatus.HIT == board.attack(2, 'B').getResults().get(0));
+        assert (AtackStatus.SUNK == board.attack(2, 'C').getResults().get(0));
+        assert (AtackStatus.RADAR == board.radarAttack(4, 'E').getResults().get(0));
+        assert (AtackStatus.RADAR == board.radarAttack(6, 'B').getResults().get(0));
+        assert (AtackStatus.INVALID == board.radarAttack(2, 'D').getResults().get(0));
     }
 
     @Test
     public void testEarlyRadar() {
         Game game = new Game();
-        game.placeShip(new Destroyer(), 1, 'A', false);
-        game.placeShip(new Minesweeper(), 3, 'A', false);
-        game.placeShip(new Battleship(), 5, 'A', false);
-        assertTrue(game.attack(1, 'A'));
+        game.placeShip(new Destroyer(), 2, 'B', false);
+        game.placeShip(new Minesweeper(), 3, 'B', false);
+        game.placeShip(new Battleship(), 5, 'B', false);
+        assertTrue(game.attack(2, 'B'));
         assertFalse(game.radarAttack(2, 'C'));
     }
 
@@ -149,24 +149,24 @@ public class GameTest { // This class has 100% coverage of all lines in Game.jav
     public void attackCQ() {
         Game game = new Game();
         Board board = new Board();
-        board.placeShip(new Destroyer(), 1, 'A', false);
-        board.placeShip(new Minesweeper(), 3, 'A', true);
-        board.placeShip(new Battleship(), 5, 'A', false);
-        board.placeSubShip(new Submarine(), 3, 'A', false, true);
-        assert (AtackStatus.HIT == board.attack(1, 'A').getResults().get(0));
-        assert (AtackStatus.MISS == board.attack(1, 'B').getResults().get(0));
-        assert (AtackStatus.MISS == board.attack(8, 'B').getResults().get(0));
-        assert (AtackStatus.HIT == board.attack(1, 'C').getResults().get(0));
-        assert (AtackStatus.SUNK == board.attack(1, 'B').getResults().get(0));
-        assertEquals(AtackStatus.HIT, board.attack(3, 'C').getResults().get(0));
-        assert (AtackStatus.SUNK == board.attack(3, 'A').getResults().get(0));
-        assert (AtackStatus.RADAR == board.radarAttack(4, 'D').getResults().get(0));
-        assert (AtackStatus.RADAR == board.radarAttack(6, 'A').getResults().get(0));
-        assert (AtackStatus.INVALID == board.radarAttack(2, 'C').getResults().get(0));
-        assert (AtackStatus.MISS == board.attack(5, 'C').getResults().get(0));
-        assert (AtackStatus.SUNK == board.attack(5, 'C').getResults().get(0));
-        assert (AtackStatus.MISS == board.attack(3, 'D').getResults().get(0));
-        assert (AtackStatus.SURRENDER == board.attack(3, 'D').getResults().get(0));
+        board.placeShip(new Destroyer(), 2, 'B', false);
+        board.placeShip(new Minesweeper(), 3, 'B', true);
+        board.placeShip(new Battleship(), 5, 'B', false);
+        board.placeSubShip(new Submarine(), 3, 'B', false, true);
+        assert (AtackStatus.HIT == board.attack(2, 'B').getResults().get(0));
+        assert (AtackStatus.MISS == board.attack(2, 'C').getResults().get(0));
+        assert (AtackStatus.MISS == board.attack(8, 'C').getResults().get(0));
+        assert (AtackStatus.HIT == board.attack(2, 'D').getResults().get(0));
+        assert (AtackStatus.SUNK == board.attack(2, 'C').getResults().get(0));
+        assertEquals(AtackStatus.HIT, board.attack(3, 'D').getResults().get(0));
+        assert (AtackStatus.SUNK == board.attack(3, 'B').getResults().get(0));
+        assert (AtackStatus.RADAR == board.radarAttack(4, 'E').getResults().get(0));
+        assert (AtackStatus.RADAR == board.radarAttack(6, 'B').getResults().get(0));
+        assert (AtackStatus.INVALID == board.radarAttack(2, 'D').getResults().get(0));
+        assert (AtackStatus.MISS == board.attack(5, 'D').getResults().get(0));
+        assert (AtackStatus.SUNK == board.attack(5, 'D').getResults().get(0));
+        assert (AtackStatus.MISS == board.attack(3, 'E').getResults().get(0));
+        assert (AtackStatus.SURRENDER == board.attack(3, 'E').getResults().get(0));
 
     }
 

--- a/src/test/java/cs361/battleships/models/LaserTest.java
+++ b/src/test/java/cs361/battleships/models/LaserTest.java
@@ -11,13 +11,13 @@ public class LaserTest {
     public void multipleAttack() {
         Game g = new Game();
         Board board = new Board();
-        board.placeShip(new Destroyer(), 2, 'A', false);
-        board.placeShip(new Minesweeper(), 3, 'A', false);
-        board.placeShip(new Battleship(), 5, 'A', false);
-        board.placeSubShip(new Submarine(), 5, 'A', false, true);
+        board.placeShip(new Destroyer(), 2, 'B', false);
+        board.placeShip(new Minesweeper(), 3, 'B', false);
+        board.placeShip(new Battleship(), 5, 'B', false);
+        board.placeSubShip(new Submarine(), 5, 'B', false, true);
 
-        assertEquals(AtackStatus.SUNK, board.attack(3,'A').getResults().get(0));
-        List<AtackStatus> a = board.attack(5,'A').getResults();
+        assertEquals(AtackStatus.SUNK, board.attack(3,'B').getResults().get(0));
+        List<AtackStatus> a = board.attack(5,'B').getResults();
         assertEquals(AtackStatus.HIT, a.get(0));
         assertEquals(AtackStatus.HIT, a.get(1));
     }
@@ -26,16 +26,16 @@ public class LaserTest {
     public void multipleCQAttack() {
         Game g = new Game();
         Board board = new Board();
-        board.placeShip(new Destroyer(), 2, 'A', false);
-        board.placeShip(new Minesweeper(), 3, 'A', false);
-        board.placeShip(new Battleship(), 5, 'B', false);
-        board.placeSubShip(new Submarine(), 5, 'A', false, true);
+        board.placeShip(new Destroyer(), 2, 'B', false);
+        board.placeShip(new Minesweeper(), 3, 'B', false);
+        board.placeShip(new Battleship(), 5, 'C', false);
+        board.placeSubShip(new Submarine(), 5, 'B', false, true);
 
-        assertEquals(AtackStatus.SUNK, board.attack(3,'A').getResults().get(0));
-        List<AtackStatus> a = board.attack(5,'D').getResults();
+        assertEquals(AtackStatus.SUNK, board.attack(3,'B').getResults().get(0));
+        List<AtackStatus> a = board.attack(5,'E').getResults();
         assertEquals(AtackStatus.MISS, a.get(0));
         assertEquals(AtackStatus.MISS, a.get(1));
-        a = board.attack(5, 'D').getResults();
+        a = board.attack(5, 'E').getResults();
         assertEquals(AtackStatus.SUNK, a.get(0));
         assertEquals(AtackStatus.SUNK, a.get(1));
     }
@@ -44,18 +44,18 @@ public class LaserTest {
     public void testSunkMultipleShips() {
         Game g = new Game();
         Board board = new Board();
-        board.placeShip(new Destroyer(), 4, 'A', false);
-        board.placeShip(new Minesweeper(), 3, 'A', false);
-        board.placeShip(new Battleship(), 5, 'B', false);
-        board.placeSubShip(new Submarine(), 5, 'A', false, true);
+        board.placeShip(new Destroyer(), 4, 'B', false);
+        board.placeShip(new Minesweeper(), 3, 'B', false);
+        board.placeShip(new Battleship(), 5, 'C', false);
+        board.placeSubShip(new Submarine(), 5, 'B', false, true);
 
-        assertEquals(AtackStatus.SUNK, board.attack(3,'A').getResults().get(0));
-        assertEquals(AtackStatus.MISS, board.attack(4,'B').getResults().get(0));
-        assertEquals(AtackStatus.SUNK, board.attack(4,'B').getResults().get(0));;
-        List<AtackStatus> a = board.attack(5,'D').getResults();
+        assertEquals(AtackStatus.SUNK, board.attack(3,'B').getResults().get(0));
+        assertEquals(AtackStatus.MISS, board.attack(4,'C').getResults().get(0));
+        assertEquals(AtackStatus.SUNK, board.attack(4,'C').getResults().get(0));;
+        List<AtackStatus> a = board.attack(5,'E').getResults();
         assertEquals(AtackStatus.MISS, a.get(0));
         assertEquals(AtackStatus.MISS, a.get(1));
-        a = board.attack(5, 'D').getResults();
+        a = board.attack(5, 'E').getResults();
         assertEquals(AtackStatus.SUNK, a.get(0));
         assertEquals(AtackStatus.SURRENDER, a.get(1));
 


### PR DESCRIPTION
There was a bug where we allowed ships to be placed on 1 and A as well as on row 12. What we really expected was to make it so ships are placed on 2B minimum and 11K as our maximum. Try live testing and see if this breaks any of our logic, it shouldn't but we should see if it does so we can debug it.